### PR TITLE
docs: update the link to the correct section of the readme

### DIFF
--- a/guide.yml
+++ b/guide.yml
@@ -30,4 +30,4 @@ categories:
     subcategories:
       - subcategory: "Contributing to the OFAI LAndscape"
         content: |
-          If you would like to contribute, please open a pull request in the [OpenForumAI Landscape Repo](https://github.com/OpenForumAI/landscape/pulls). If you are unsure about how to start, you could check out our [README](https://github.com/OpenForumAI/landscape?tab=readme-ov-file#ofai-research-landscape) or email [info@openforumai.org](mailto:info@openforumai.org) 
+          If you would like to contribute, please open a pull request in the [OpenForumAI Landscape Repo](https://github.com/OpenForumAI/landscape/pulls). If you are unsure about how to start, you could check out our [README](https://github.com/OpenForumAI/landscape?tab=readme-ov-file#contributing-to-the-project) or email [info@openforumai.org](mailto:info@openforumai.org) 


### PR DESCRIPTION
The section didnt exist before so I couldnt link to it